### PR TITLE
fix: removes sprout cache

### DIFF
--- a/latest/sprout
+++ b/latest/sprout
@@ -72,4 +72,5 @@ else
 	rm -f /etc/systemd/system/grlx-sprout.service
 	rm -f /usr/local/bin/grlx-sprout
 	rm -rf /etc/grlx
+    rm -rf /var/cache/grlx
 fi


### PR DESCRIPTION
Removes /var/cache/grlx on the sprout installer.