### PR TITLE
docs: align install demo tapes with README commands

### DIFF
--- a/docs/farmer-install.tape
+++ b/docs/farmer-install.tape
@@ -3,7 +3,7 @@ Output farmer-install.gif
 Set FontSize 30
 Set Width 2500
 Set Height 600
-Type "curl -L https://bootstrap.grlx.dev/latest/farmer | PATH=$PATH:/usr/sbin sudo bash"
+Type "curl -fsSL https://bootstrap.grlx.dev/latest/farmer | PATH=$PATH:/usr/sbin sudo bash"
 Sleep 2s
 Enter
 Sleep 1.5s

--- a/docs/grlx-install.tape
+++ b/docs/grlx-install.tape
@@ -5,7 +5,7 @@ Set FontSize 30
 Set Width 1500
 Set Height 600
 # replace 'linux' with darwin if you're on macOS
-Type "curl -L https://releases.grlx.dev/linux/amd64/latest/grlx > grlx"
+Type "curl -fsSL https://releases.grlx.dev/linux/amd64/latest/grlx -o grlx"
 Enter
 Hide
 Sleep 45s

--- a/docs/sprout-install.tape
+++ b/docs/sprout-install.tape
@@ -2,7 +2,7 @@ Output sprout-install.gif
 Set FontSize 30
 Set Width 2500
 Set Height 600
-Type "curl -L https://bootstrap.grlx.dev/latest/sprout | FARMER_INTERFACE=localhost sudo -E bash"
+Type "curl -fsSL https://bootstrap.grlx.dev/latest/sprout | FARMERINTERFACE=localhost sudo -E bash"
 Sleep 5s
 Enter
 Sleep 2.5s


### PR DESCRIPTION
## Summary
- update the VHS tape commands to use the same fail-fast curl flags as the README
- fix the sprout install tape to use the correct `FARMERINTERFACE` variable name
- switch the grlx install tape to `-o grlx` so the recorded command matches the docs

## Testing
- `git diff -- docs/*.tape`
- `vhs farmer-install.tape && vhs grlx-install.tape && vhs sprout-install.tape` *(fails in this environment because headless Chromium crashes during recording)*